### PR TITLE
避免重复配置

### DIFF
--- a/generator-web/src/main/resources/statics/js/common.js
+++ b/generator-web/src/main/resources/statics/js/common.js
@@ -42,3 +42,28 @@ window.confirm = function(msg, callback){
 function isBlank(value) {
     return !value || !/\S/.test(value)
 }
+
+function setCookie(key, val, expire_second) {
+	var d = new Date();
+	var expires ="";
+	if (expire_second){
+		d.setDate(d.getTime()+(expire_second*1000));
+		expires='; expires=' + d.toGMTSring();
+	}
+	document.cookie = key + "="+ val + expires;
+}
+
+function getCookie(name) {
+	var data = "";
+	if (document.cookie){
+		var arr = document.cookie.split(';');
+		for (var str of arr) {
+			var temp = str.split("=")
+			if (temp[0].replace(/(^\s*)/g,'') === name){
+				data = unescape(temp[1]);
+				break
+			}
+		}
+	}
+	return data;
+}

--- a/generator-web/src/main/resources/statics/js/main.js
+++ b/generator-web/src/main/resources/statics/js/main.js
@@ -166,7 +166,7 @@ function setAllCookie() {
 }
 
 function setOneCookie(key) {
-	setCookie(key, vm.formData.options[key]);
+	setCookie(key, vm.formData.options[key], 60 * 60 * 24 * 7);
 }
 
 /**

--- a/generator-web/src/main/resources/statics/js/main.js
+++ b/generator-web/src/main/resources/statics/js/main.js
@@ -123,6 +123,7 @@ const vm = new Vue({
 					error("生成失败");
 					return;
 				}
+				setAllCookie();
 				//console.log(res.outputJson);
 				vm.outputJson=res.outputJson;
 				// console.log(vm.outputJson["bootstrap-ui"]);
@@ -154,3 +155,41 @@ const vm = new Vue({
 	}
 });
 
+/**
+ * 将所有 需要 保留历史纪录的字段写入Cookie中
+ */
+function setAllCookie() {
+	var arr = list_key_need_load();
+	for (var str of arr){
+		setOneCookie(str);
+	}
+}
+
+function setOneCookie(key) {
+	setCookie(key, vm.formData.options[key]);
+}
+
+/**
+ * 将所有 历史纪录 重加载回页面
+ */
+function loadAllCookie() {
+	//console.log(vm);
+	var arr = list_key_need_load();
+	for (var str of arr){
+		loadOneCookie(str);
+	}
+}
+
+function loadOneCookie(key) {
+	if (getCookie(key)!==""){
+		vm.formData.options[key] = getCookie(key);
+	}
+}
+
+/**
+ * 将 所有 需要 纪录的 字段写入数组
+ * @returns {[string]}
+ */
+function list_key_need_load() {
+	return ["authorName","packageName","returnUtilSuccess","returnUtilFailure","ignorePrefix","tinyintTransType","timeTransType"];
+}

--- a/generator-web/src/main/resources/statics/js/main.js
+++ b/generator-web/src/main/resources/statics/js/main.js
@@ -166,7 +166,7 @@ function setAllCookie() {
 }
 
 function setOneCookie(key) {
-	setCookie(key, vm.formData.options[key], 60 * 60 * 24 * 7);
+	setCookie(key, vm.formData.options[key]);
 }
 
 /**

--- a/generator-web/src/main/resources/templates/code-generator/jpa/jpacontroller.ftl
+++ b/generator-web/src/main/resources/templates/code-generator/jpa/jpacontroller.ftl
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 </#if>
 /**
  * @description ${classInfo.classComment}

--- a/generator-web/src/main/resources/templates/code-generator/jpa/repository.ftl
+++ b/generator-web/src/main/resources/templates/code-generator/jpa/repository.ftl
@@ -1,4 +1,4 @@
-<#if isWithPackage?exists && isWithPackage==true>package ${packageName}.mapper;</#if>
+<#if isWithPackage?exists && isWithPackage==true>package ${packageName}.repository;</#if>
 <#if isAutoImport?exists && isAutoImport==true>import ${packageName}.entity.${classInfo.className};
 
 <#if classInfo.fieldList?exists && classInfo.fieldList?size gt 0>

--- a/generator-web/src/main/resources/templates/main.html
+++ b/generator-web/src/main/resources/templates/main.html
@@ -140,6 +140,7 @@
     vm.formData.options.returnUtilSuccess="${(value.returnUtilSuccess)!!}";
     vm.formData.options.returnUtilFailure="${(value.returnUtilFailure)!!}";
     vm.outputStr="${(value.outputStr)!!}";
+    loadAllCookie()
 </script>
 </body>
 </html>


### PR DESCRIPTION
背景 : 当重新打开一个页面时,有很多设置需要重复操作,浪费时间
修改 :
    1 main.html: 增加 加载 cookie 的逻辑
    2 common.js: 增加 cookie 设置 和 get 的 通用逻辑
    3 main.js: 增加 将所有需要纪录的字段写入cookie逻辑,并加载到页面