### PR TITLE
parser: 解析出错时打印出错的行信息

### DIFF
--- a/generator-web/src/main/java/com/softdev/system/generator/util/TableParseUtil.java
+++ b/generator-web/src/main/java/com/softdev/system/generator/util/TableParseUtil.java
@@ -173,7 +173,13 @@ public class TableParseUtil {
                     String columnName = "";
                     columnLine = columnLine.replaceAll("`", " ").replaceAll("\"", " ").replaceAll("'", "").replaceAll("  ", " ").trim();
                     //如果遇到username varchar(65) default '' not null,这种情况，判断第一个空格是否比第一个引号前
-                    columnName = columnLine.substring(0, columnLine.indexOf(" "));
+                    try {
+                        columnName = columnLine.substring(0, columnLine.indexOf(" "));
+                    } catch (StringIndexOutOfBoundsException e) {
+                        System.out.println("err happened: " + columnLine);
+                        throw e;
+                    }
+
                     // field Name
                     // 2019-09-08 yj 添加是否下划线转换为驼峰的判断
                     String fieldName = null;


### PR DESCRIPTION
当有索引和额外的换行时, 解析似乎有问题, 导致一行只有一列如 `name`, 导致报错 `string out of index`.

没有仔细研究 parser 找到 root case, 这个修复可以打印出错的是哪一行, 然后在页面格式化那一行, 即可绕过这个错误.