### PR TITLE
新建了jpa-starp模板，是对jpa模板的一些小修改

### DIFF
--- a/generator-web/src/main/java/com/softdev/system/generator/controller/GeneratorController.java
+++ b/generator-web/src/main/java/com/softdev/system/generator/controller/GeneratorController.java
@@ -84,6 +84,7 @@ public class GeneratorController {
 
         //3.generate the code by freemarker templates with parameters . Freemarker根据参数和模板生成代码
         Map<String, String> result = generatorService.getResultByParams(paramInfo.getOptions());
+        log.info("result {}",result);
         log.info("table:{} - time:{} ", MapUtil.getString(result,"tableName"),new Date());
         return ReturnT.ok().put("outputJson",result);
     }

--- a/generator-web/src/main/resources/template.json
+++ b/generator-web/src/main/resources/template.json
@@ -229,5 +229,25 @@
         "description": "rr-service"
       }
     ]
+  },
+
+  {
+    "group": "jpa-starp",
+    "templates": [{
+      "id": "101",
+      "name": "starp-entity",
+      "description": "entity"
+    },
+      {
+        "id": "102",
+        "name": "starp-repository",
+        "description": "repository"
+      },
+      {
+        "id": "103",
+        "name": "starp-jpa-controller",
+        "description": "jpacontroller"
+      }
+    ]
   }
 ]

--- a/generator-web/src/main/resources/templates/code-generator/jpa-starp/starp-entity.ftl
+++ b/generator-web/src/main/resources/templates/code-generator/jpa-starp/starp-entity.ftl
@@ -1,0 +1,60 @@
+<#if isWithPackage?exists && isWithPackage==true>package ${packageName}.entity;</#if>
+
+<#if isAutoImport?exists && isAutoImport==true>
+<#if isLombok?exists && isLombok==true>import lombok.Data;</#if>
+import java.util.Date;
+import java.util.List;
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.GeneratedValue;
+<#if isSwagger?exists && isSwagger==true>
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;</#if>
+</#if>
+/**
+ * @description ${classInfo.classComment}
+ * @author ${authorName}
+ * @date ${.now?string('yyyy-MM-dd')}
+ */
+@Entity
+@Builder
+@AllArgsConstructor
+<#if isLombok?exists && isLombok==true>@Data</#if>
+<#if isComment?exists && isComment==true>@Table(name="${classInfo.originTableName}")</#if><#if isSwagger?exists && isSwagger==true>
+@ApiModel("${classInfo.classComment}")</#if>
+public class ${classInfo.className} implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @ApiModelProperty("id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+<#if classInfo.fieldList?exists && classInfo.fieldList?size gt 0>
+<#list classInfo.fieldList as fieldItem >
+    <#if isComment?exists && isComment==true>/**
+    * ${fieldItem.fieldComment}
+    */</#if><#if isSwagger?exists && isSwagger==true>
+    @ApiModelProperty("${fieldItem.fieldComment}")</#if>
+    <#if isComment?exists && isComment==true>@Column(name="${fieldItem.columnName}")</#if>
+    private ${fieldItem.fieldClass} ${fieldItem.fieldName};
+
+</#list>
+    public ${classInfo.className}() {
+    }
+</#if>
+
+<#if isLombok?exists && isLombok==false>
+    public ${fieldItem.fieldClass} get${fieldItem.fieldName?cap_first}() {
+        return ${fieldItem.fieldName};
+    }
+
+    public void set${fieldItem.fieldName?cap_first}(${fieldItem.fieldClass} ${fieldItem.fieldName}) {
+        this.${fieldItem.fieldName} = ${fieldItem.fieldName};
+    }
+</#if>
+}

--- a/generator-web/src/main/resources/templates/code-generator/jpa-starp/starp-jpa-controller.ftl
+++ b/generator-web/src/main/resources/templates/code-generator/jpa-starp/starp-jpa-controller.ftl
@@ -1,0 +1,106 @@
+<#if isWithPackage?exists && isWithPackage==true>package ${packageName}.controller;</#if>
+<#if isAutoImport?exists && isAutoImport==true>
+import ${packageName}.entity.${classInfo.className};
+import ${packageName}.repository.${classInfo.className}Repository;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+</#if>
+/**
+ * @description ${classInfo.classComment}
+ * @author ${authorName}
+ * @date ${.now?string('yyyy-MM-dd')}
+ */
+
+@Slf4j
+@Api(tags = "${classInfo.className?uncap_first}")
+@CrossOrigin
+@RestController
+@RequestMapping("/${classInfo.className?uncap_first}")
+public class ${classInfo.className}Controller {
+
+    @Autowired
+    private ${classInfo.className}Repository ${classInfo.className?uncap_first}Repository;
+
+    /**
+    * 新增或编辑
+    */
+    @PostMapping("/save")
+    @ApiOperation(value = "save ${classInfo.className}", notes = "save ${classInfo.className}")
+    public Object save(@RequestBody ${classInfo.className} ${classInfo.className?uncap_first}){
+        try {
+            return ReturnT.success(${classInfo.className?uncap_first}Repository.save(${classInfo.className?uncap_first}));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ReturnT.error("保存失败");
+        }
+
+    }
+
+    /**
+    * 删除
+    */
+    @PostMapping("/delete")
+    @ApiOperation(value = "delete ${classInfo.className}", notes = "delete ${classInfo.className}")
+    public Object delete(int id){
+        Optional<${classInfo.className}> ${classInfo.className?uncap_first}=${classInfo.className?uncap_first}Repository.findById(id);
+        if(${classInfo.className?uncap_first}.isPresent()){
+            ${classInfo.className?uncap_first}Repository.deleteById(id);
+            return ${returnUtilSuccess}("删除成功");
+        }else{
+            return ${returnUtilFailure}("没有找到该对象");
+        }
+    }
+
+    /**
+    * 查询
+    */
+    @PostMapping("/find")
+    @ApiOperation(value = "find ${classInfo.className} by id", notes = "find ${classInfo.className} by id")
+    public Object find(int id){
+        Optional<${classInfo.className}> ${classInfo.className?uncap_first}=${classInfo.className?uncap_first}Repository.findById(id);
+        if(${classInfo.className?uncap_first}.isPresent()){
+            return ${returnUtilSuccess}(${classInfo.className?uncap_first}.get());
+        }else{
+            return ${returnUtilFailure}("没有找到该对象");
+        }
+    }
+
+    /**
+    * 分页查询
+    */
+    @PostMapping("/list")
+    @ApiOperation(value = "list ${classInfo.className}", notes = "list ${classInfo.className}")
+    public Object list(@RequestBody ${classInfo.className} ${classInfo.className?uncap_first},
+                        @RequestParam(required = false, defaultValue = "0") int pageNumber,
+                        @RequestParam(required = false, defaultValue = "10") int pageSize) {
+
+            try {
+                //创建匹配器，需要查询条件请修改此处代码
+                ExampleMatcher matcher = ExampleMatcher.matchingAll();
+
+                //创建实例
+                Example<${classInfo.className}> example = Example.of(${classInfo.className?uncap_first}, matcher);
+                //分页构造
+                Pageable pageable = PageRequest.of(pageNumber,pageSize);
+
+                return ReturnT.success(${classInfo.className?uncap_first}Repository.findAll(example, pageable));
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                return ReturnT.error(e.getMessage());
+            }
+
+    }
+
+}

--- a/generator-web/src/main/resources/templates/code-generator/jpa-starp/starp-repository.ftl
+++ b/generator-web/src/main/resources/templates/code-generator/jpa-starp/starp-repository.ftl
@@ -1,0 +1,26 @@
+<#if isWithPackage?exists && isWithPackage==true>package ${packageName}.repository;</#if>
+<#if isAutoImport?exists && isAutoImport==true>import ${packageName}.entity.${classInfo.className};
+
+<#if classInfo.fieldList?exists && classInfo.fieldList?size gt 0>
+    <#list classInfo.fieldList as fieldItem >
+        <#if fieldItem.fieldClass == "Date">
+            <#assign importDdate = true />
+        </#if>
+    </#list>
+</#if>
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+</#if>
+/**
+ * @description ${classInfo.classComment}
+ * @author ${authorName}
+ * @date ${.now?string('yyyy-MM-dd')}
+ */
+@Repository
+public interface ${classInfo.className}Repository extends JpaRepository<${classInfo.className},Integer> {
+
+
+
+}


### PR DESCRIPTION
增加了我自己用的比较舒服的jpa模板，但是我不知道自己的模板是否合理，所以我是新建了jpa-starp这个模板，而不是在原来的jpa基础上改。

entity的id，原来是这样的，貌似缺少了 id字段，只有注解了。

 @Id
  @GeneratedValue

把他改成这样了

@Id
@ApiModelProperty("id")
@GeneratedValue(strategy = GenerationType.IDENTITY)
private Integer id;

用  @GeneratedValue(strategy = GenerationType.IDENTITY) 这个策略自增

controller的所有操作都加了try catch 并且返回值都用 ReturnT 包裹，使得接口一致

controller增加了 swagger 和 CrossOrigin 跨域。
实体用 @RequestBody 传参，这样form 表单是在body而不是 param 里

文档：增加了我自己用的比较舒服的jpa模板，....
链接：http://note.youdao.com/noteshare?id=b34b62c8b6fcd6b4481704d2c79a56fa

这里有两种模板生成的代码的对比
文档：jpa 和 jpa starp 的对比.note
链接：http://note.youdao.com/noteshare?id=9e729ca22368084791fcdc2a1f2dc29f


文档：jpa 和 jpa starp 的对比.note
链接：http://note.youdao.com/noteshare?id=9e729ca22368084791fcdc2a1f2dc29f