### PR TITLE
fix: 驼峰列名转命名风格错误问题 #143

### DIFF
--- a/generator-web/pom.xml
+++ b/generator-web/pom.xml
@@ -17,7 +17,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/generator-web/src/main/java/com/softdev/system/generator/entity/NonCaseString.java
+++ b/generator-web/src/main/java/com/softdev/system/generator/entity/NonCaseString.java
@@ -1,0 +1,152 @@
+package com.softdev.system.generator.entity;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * String 包装类
+ * <p>
+ * 忽略大小写
+ **考虑增加这个类是, 如果在 StringUtils 中加工具方法, 使用起来代码非常冗长且不方便
+ * @author Nisus
+ * @see String
+ */
+@AllArgsConstructor
+public class NonCaseString implements CharSequence {
+    private String value;
+
+    public static NonCaseString of(String str) {
+        assert str != null;
+        return new NonCaseString(str);
+    }
+
+
+    /**
+     * {@link String#indexOf(String)} 增强, 忽略大小写
+     */
+    public int indexOf(String m) {
+        String text = this.value;
+        if (text == null || m == null || text.length() < m.length()) {
+            return -1;
+        }
+        return text.toLowerCase().indexOf(m.toLowerCase());
+    }
+
+    /**
+     * {@link String#lastIndexOf(String)} 增强, 忽略大小写
+     */
+    public int lastIndexOf(String m) {
+        String text = this.value;
+        if (text == null || m == null || text.length() < m.length()) {
+            return -1;
+        }
+        return text.toLowerCase().lastIndexOf(m.toLowerCase());
+    }
+
+    /**
+     * 是否包含, 大小写不敏感
+     * <pre
+     * "abcxyz" 包含 "abc" => true
+     * "abcxyz" 包含 "ABC" => true
+     * "abcxyz" 包含 "aBC" => true
+     * </pre>
+     *
+     * @param m 被包含字符串
+     */
+    public boolean contains(String m) {
+        String text = this.value;
+        if (text.length() < m.length()) {
+            return false;
+        }
+        return text.toLowerCase().contains(m.toLowerCase());
+    }
+
+    /**
+     * 任意一个包含返回true
+     * <pre>
+     * containsAny("abcdef", "a", "b)
+     * 等价
+     * "abcdef".contains("a") || "abcdef".contains("b")
+     * </pre>
+     *
+     * @param matchers 多个要判断的被包含项
+     */
+    public boolean containsAny(String... matchers) {
+        for (String matcher : matchers) {
+            if (contains(matcher)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 所有都包含才返回true
+     *
+     * @param matchers 多个要判断的被包含项
+     */
+    public boolean containsAllIgnoreCase(String... matchers) {
+        for (String matcher : matchers) {
+            if (contains(matcher) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public NonCaseString trim() {
+        return NonCaseString.of(this.value.trim());
+    }
+
+    public NonCaseString replace(char oldChar, char newChar) {
+        return NonCaseString.of(this.value.replace(oldChar, newChar));
+    }
+
+    public NonCaseString replaceAll(String regex, String replacement) {
+        return NonCaseString.of(this.value.replaceAll(regex, replacement));
+    }
+
+    public NonCaseString substring(int beginIndex) {
+        return NonCaseString.of(this.value.substring(beginIndex));
+    }
+
+    public NonCaseString substring(int beginIndex, int endIndex) {
+        return NonCaseString.of(this.value.substring(beginIndex, endIndex));
+    }
+
+    public boolean isNotEmpty() {
+        return !this.value.isEmpty();
+    }
+
+    @Override
+    public int length() {
+        return this.value.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+        return this.value.charAt(index);
+    }
+
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        return this.value.subSequence(start, end);
+    }
+
+    public String[] split(String regex) {
+        return this.value.split(regex);
+    }
+
+
+    /**
+     * @return 原始字符串
+     */
+    public String get() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/generator-web/src/main/java/com/softdev/system/generator/util/StringUtils.java
+++ b/generator-web/src/main/java/com/softdev/system/generator/util/StringUtils.java
@@ -40,7 +40,7 @@ public class StringUtils {
             boolean flag = false;
             for (int i = 0; i < underscoreName.length(); i++) {
                 char ch = underscoreName.charAt(i);
-                if ("_".charAt(0) == ch) {
+                if ('_' == ch) {
                     flag = true;
                 } else {
                     if (flag) {
@@ -54,6 +54,42 @@ public class StringUtils {
         }
         return result.toString();
     }
+
+    /**
+     * 转 user_name 风格
+     *
+     * 不管原始是什么风格
+     */
+    public static String toUnderline(String str, boolean upperCase) {
+        if (str == null || str.trim().isEmpty()) {
+            return str;
+        }
+
+        StringBuilder result = new StringBuilder();
+        boolean preIsUnderscore = false;
+        for (int i = 0; i < str.length(); i++) {
+            char ch = str.charAt(i);
+            if (ch == '_') {
+                preIsUnderscore = true;
+            } else if (ch == '-') {
+                ch = '_';
+                preIsUnderscore = true; // -A -> _a
+            } else if (ch >= 'A' && ch <= 'Z') {
+                // A -> _a
+                if (!preIsUnderscore && i > 0) { // _A -> _a
+                    result.append("_");
+                }
+                preIsUnderscore = false;
+            } else {
+                preIsUnderscore = false;
+            }
+            result.append(upperCase ? Character.toUpperCase(ch) : Character.toLowerCase(ch));
+        }
+
+        return result.toString();
+    }
+
+
     public static boolean isNotNull(String str){
         return org.apache.commons.lang3.StringUtils.isNotEmpty(str);
     }

--- a/generator-web/src/main/resources/statics/js/main.js
+++ b/generator-web/src/main/resources/statics/js/main.js
@@ -36,6 +36,9 @@ const vm = new Vue({
 				"  'user_name' varchar(255) NOT NULL COMMENT '用户名',\n" +
 				"  'status' tinyint(1) NOT NULL COMMENT '状态',\n" +
 				"  'create_time' datetime NOT NULL COMMENT '创建时间',\n" +
+				//下面可以留着方便开发调试时打开
+				// "  `updateTime` datetime NOT NULL COMMENT '更新时间',\n" +
+				// "  ABc_under_Line-Hypen-CamelCase varchar comment '乱七八糟的命名风格',\n" +
 				"  PRIMARY KEY ('user_id')\n" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='用户信息'",
 			options: {

--- a/generator-web/src/test/java/FooTest.java
+++ b/generator-web/src/test/java/FooTest.java
@@ -1,0 +1,25 @@
+import com.softdev.system.generator.util.StringUtils;
+
+public class FooTest {
+
+    public static void main(String[] args) {
+        // String updateTime = StringUtils.underlineToCamelCase("updateTime");
+        // System.out.println(updateTime);
+
+
+        // System.out.println(CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, "userName"));
+        // System.out.println(CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, "userNAme-UUU"));
+
+        System.out.println(StringUtils.toUnderline("userName",false));
+        System.out.println(StringUtils.toUnderline("UserName",false));
+        System.out.println(StringUtils.toUnderline("user_NameGgg_x-UUU",false));
+        System.out.println(StringUtils.toUnderline("username",false));
+
+        System.out.println(StringUtils.toUnderline("userName",true));
+        System.out.println(StringUtils.toUnderline("UserName",true));
+        System.out.println(StringUtils.toUnderline("user_NameGgg_x-UUU",true));
+        System.out.println(StringUtils.toUnderline("username",true));
+    }
+
+
+}


### PR DESCRIPTION
1. fix #143
2. 增强转下划线命名风格, 对原始风格不敏感. 支持各种命名风格的列名 to 下划线
3. 附带增加 NonCaseString 大小写不敏感字符串包装类, 简化编码
4. 几点代码小优化